### PR TITLE
task-LUX-28-approve contribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "undo:seeds": "sequelize db:seed:undo:all",
     "lint": "eslint .",
     "test": "jest --coverage --runInBand --forceExit",
-    "pretest": "NODE_ENV=test yarn undo:migration && NODE_ENV=test yarn migration  && NODE_ENV=test yarn undo:seeds && NODE_ENV=test yarn seeds"
+    "pretest": "NODE_ENV=test yarn db:refresh"
   },
   "repository": {
     "type": "git",

--- a/src/graphql/resolvers/__tests__/contribution.test.js
+++ b/src/graphql/resolvers/__tests__/contribution.test.js
@@ -9,14 +9,37 @@ const { USER_PASSWORD } = process.env;
 
 let userToken;
 
+let secretaryToken;
+
+let userTwoToken;
+
 describe('Contribution Test Suite', () => {
   const input = {
     email: 'example@example.com',
     password: USER_PASSWORD,
   };
 
+  const userTwoInput = {
+    email: 'example@example2.com',
+    password: USER_PASSWORD,
+  };
+
   beforeAll(async () => {
     userToken = await userResolver.Mutation.userLogin(null, { input }, { res });
+    await userResolver.Mutation.updateUser(
+      null,
+      { id: 2, input: { accountStatus: 'activated' } },
+      { token: userToken.accessToken },
+    );
+    userTwoToken = await userResolver.Mutation.userLogin(null, { input: userTwoInput }, { res });
+  });
+
+  afterAll(async () => {
+    await userResolver.Mutation.updateUser(
+      null,
+      { id: 2, input: { accountStatus: 'disactivated' } },
+      { token: userToken.accessToken },
+    );
   });
 
   it('should test pay contribution and upload bankReceipt', async () => {
@@ -52,5 +75,87 @@ describe('Contribution Test Suite', () => {
       { token: userToken.accessToken },
     );
     expect(results[0].dataValues.userId).toBe(1);
+  });
+
+  it('should throw an error when a someone in charge of approving tries to approve his or her contribution', async () => {
+    try {
+      jest.spyOn(contributionResolver.Mutation, 'approveContribution');
+      await contributionResolver.Mutation.approveContribution(
+        null,
+        {
+          id: 1,
+        },
+        { token: userToken.accessToken },
+      );
+    } catch (err) {
+      expect(err.constructor.name).toEqual('ForbiddenError');
+      expect(err.message).toEqual('Sorry, you can not approve your own contribution!');
+    }
+  });
+  it('should throw an error when someone who is not in charger tries to approve a contribution', async () => {
+    try {
+      jest.spyOn(contributionResolver.Mutation, 'approveContribution');
+      await contributionResolver.Mutation.approveContribution(
+        null,
+        {
+          id: 1,
+        },
+        { token: userTwoToken.accessToken },
+      );
+    } catch (err) {
+      expect(err.constructor.name).toEqual('AuthenticationError');
+      expect(err.message).toEqual('Sorry, you are neither a secretary nor fiance personnel.');
+    }
+  });
+});
+
+
+describe('eage cases', () => {
+  const input = {
+    email: 'example@example2.com',
+    password: USER_PASSWORD,
+  };
+  beforeAll(async () => {
+    await userResolver.Mutation.updateUser(
+      null,
+      { id: 2, input: { accountStatus: 'activated', positionId: 3 } },
+      { token: userToken.accessToken },
+    );
+    secretaryToken = await userResolver.Mutation.userLogin(null, { input }, { res });
+  });
+
+  afterAll(async () => {
+    await userResolver.Mutation.updateUser(
+      null,
+      { id: 2, input: { accountStatus: 'disactivated', positionId: 1 } },
+      { token: userToken.accessToken },
+    );
+  });
+
+  it('should test approve contribution', async () => {
+    jest.spyOn(contributionResolver.Mutation, 'approveContribution');
+    const results = await contributionResolver.Mutation.approveContribution(
+      null,
+      {
+        id: 1,
+      },
+      { token: secretaryToken.accessToken },
+    );
+    expect(results.approved).toBe(true);
+  });
+  it('should throw an error when a someone in charge of approving tries to approve a contribution which does not exist', async () => {
+    try {
+      jest.spyOn(contributionResolver.Mutation, 'approveContribution');
+      await contributionResolver.Mutation.approveContribution(
+        null,
+        {
+          id: 0,
+        },
+        { token: secretaryToken.accessToken },
+      );
+    } catch (err) {
+      expect(err.constructor.name).toEqual('ApolloError');
+      expect(err.message).toEqual('Contribution not found!');
+    }
   });
 });

--- a/src/graphql/resolvers/contribution.resolver.js
+++ b/src/graphql/resolvers/contribution.resolver.js
@@ -2,6 +2,7 @@ import { Contribution } from '../../services/contribution.services';
 import { generalValidator } from '../../helpers/general.validator';
 import { contributionSchema } from '../../utils/schemas/contribution.schemas';
 import { decodeToken } from '../../helpers/user.helpers';
+import { isSecretaryOrFinance } from '../../utils/user.utils';
 
 export const contributionResolver = {
   Mutation: {
@@ -10,6 +11,15 @@ export const contributionResolver = {
       await generalValidator(input, contributionSchema);
       const contribution = new Contribution(input);
       const results = contribution.payContribution(loggedInUser, file);
+      return results;
+    },
+    approveContribution: async (_, { id }, { token }) => {
+      const user = await decodeToken(token);
+      isSecretaryOrFinance(user);
+      const approve = new Contribution({});
+
+      const results = await approve.approveContribution(id, user);
+
       return results;
     },
   },

--- a/src/graphql/resolvers/user.resolver.js
+++ b/src/graphql/resolvers/user.resolver.js
@@ -10,14 +10,7 @@ import {
   userUpdateProfileSchema,
 } from '../../utils/schemas/user.schemas';
 import { isAdmin, addTokenToResults } from '../../utils/user.utils';
-// import { Role } from '../../services/role.services';
-// import { Position } from '../../services/position.services';
 import { Saving } from '../../services/saving.services';
-// import { Contribution } from '../../services/contribution.services';
-// import { Report } from '../../services/report.services';
-// import { Vote } from '../../services/vote.services';
-// import { VoteEvent } from '../../services/voteEvent.services';
-// import { Event } from '../../services/event.services';
 import { GeneralClass } from '../../services/generalClass.service';
 import { RolePosition } from '../../services/rolePostion.service';
 

--- a/src/graphql/typesDefs/mutations/contribution.mutations.js
+++ b/src/graphql/typesDefs/mutations/contribution.mutations.js
@@ -4,6 +4,7 @@ export const contributionMutation = gql`
 
 extend type Mutation{
     addContribution(input: ContributionInput!, file: Upload): Contribution
+    approveContribution(id: ID!): Contribution
 }
 
 `;

--- a/src/sequelize/seeders/20200426095124-seeders-position.js
+++ b/src/sequelize/seeders/20200426095124-seeders-position.js
@@ -12,6 +12,18 @@ module.exports = {
       createdAt: new Date(),
       updatedAt: new Date(),
     },
+    {
+      name: 'secretary',
+      description: 'this is the secretary',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'finance maneger',
+      description: 'this is the finance personnel',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
   ]),
   down: (queryInterface) => queryInterface.bulkDelete('Positions', null, {}),
 };

--- a/src/sequelize/seeders/20230426100454-seeders-user.js
+++ b/src/sequelize/seeders/20230426100454-seeders-user.js
@@ -19,7 +19,7 @@ module.exports = {
       phoneNo: '+230494484475',
       avatar: 'image',
       roleId: 1,
-      positionId: 1,
+      positionId: 3,
       savingId: 1,
       verified: true,
       createdAt: new Date(),

--- a/src/utils/user.utils.js
+++ b/src/utils/user.utils.js
@@ -33,3 +33,8 @@ export const addTokenToResults = async (res) => {
     },
   };
 };
+
+export const isSecretaryOrFinance = (user) => {
+  if ((user.positionId !== 3) && (user.positionId !== 4)) throw new AuthenticationError('Sorry, you are neither a secretary nor fiance personnel.');
+  return true;
+};


### PR DESCRIPTION

### Description
- approve contribution by personnel in charge
- restricts other people to approve a contribution
- tests

### How to test
- clone repo

- checkout to **task-LUX-28-approve-contribution**

- run **yarn install**

- add all environment values to your .env file

- run **yarn start:dev** to start server

- run **yarn test** to run tests

- now you can go to **http://localhost:5050/graphql** to run approveContribution mutation

### How has this been tested?

- [ ]  Unit testing
- [x]  Integration testing
- [ ]  End-to-end testing

### Jira
[LUX-28](https://amanilabs.atlassian.net/browse/LUX-28)
